### PR TITLE
Update quizdefinitions-get-quizdefinition-by-id.md

### DIFF
--- a/docs/api/beasts-get-beast-by-id.md
+++ b/docs/api/beasts-get-beast-by-id.md
@@ -1,4 +1,4 @@
-# GET beasts by ID
+# GET beast by ID
 
 Returns all `beasts` specified by the `beastId` parameter, if it exists.
 

--- a/docs/api/quizdefinitions-get-quizdefinition-by-id.md
+++ b/docs/api/quizdefinitions-get-quizdefinition-by-id.md
@@ -1,4 +1,4 @@
-# GET Quiz Definitions by quiz ID
+# GET quiz definition by quiz ID
 
 Returns all `quizdefinitions` specified by the `quizId` parameter, if it exists.
 
@@ -14,7 +14,6 @@ Returns all `quizdefinitions` specified by the `quizId` parameter, if it exists.
 | Name | Type | Description |
 | ------------- | ----------- | ----------- |
 | `quizId` | string | The ID of the quiz to return. |
-
 
 ## Authorization
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,4 +27,4 @@ See these topics for more details on the resources that the REST API uses:
 
 * [Quiz definitions](./api/quizdefinitions.md)
   * [GET quiz definitions](./api/quizdefinitions-get-quiz-definitions.md)
-  * [GET quiz definitions by ID](./api/quizdefinitions-get-quiz-definitions-by-id)
+  * [GET quiz definitions by ID](./api/quizdefinitions-get-quizdefinition-by-id.md)

--- a/docs/overview/inner-beast-overview.md
+++ b/docs/overview/inner-beast-overview.md
@@ -25,4 +25,4 @@ The Inner Beast Service uses these two resources: `beasts` and `quizdefinitions`
   * [GET beasts by ID](../api/beasts-get-beasts-by-id.md)
 * [Quiz definitions](../api/quizdefinitions.md)
   * [GET quiz definitions](../api/quizdefinitions-get-quiz-definitions.md)
-  * [GET quiz definitions by ID](../api/quizdefinitions-get-quiz-definitions-by-id)
+  * [GET quiz definitions by ID](../api/quizdefinitions-get-quizdefinition-by-id.md)


### PR DESCRIPTION
Create new-quizdefinitions-get-quizdefinition-by-id

Update quizdefinitions-get-quizdefinition-by-id.md

Rename new-quizdefinitions-get-quizdefinition-by-id.md to quizdefinitions-get-quizdefinition-by-id.md

Delete docs/api/quizdefinitions-get-quiz-definitions-by-id

Update new-quizdefinitions-get-quizdefinition-by-id.md

Rename new-quizdefinitions-get-quizdefinition-by-id to new-quizdefinitions-get-quizdefinition-by-id.md

Update and rename beasts-get-beasts-by-id.md to beasts-get-beast-by-id.md

Fix links to GET quiz definitions by ID

Fix link on Overview and Index to GET quiz definitions by ID